### PR TITLE
Handle invalid DST values

### DIFF
--- a/geomagnetic-monitor.js
+++ b/geomagnetic-monitor.js
@@ -44,6 +44,18 @@ const geoMagApp = (function() {
         ]
     };
 
+    // Configuración específica para GitHub Pages
+    const IS_PRODUCTION = window.location.hostname === 'ttumn.github.io';
+    if (IS_PRODUCTION) {
+        CONFIG.SOURCE_TIMEOUTS = {
+            ...CONFIG.SOURCE_TIMEOUTS,
+            gfzApi: 30000,
+            kpNoaa: 40000,
+            dst: 60000,
+            ksa: 30000,
+        };
+    }
+
     // ================== ESTADO GLOBAL ==================
     const state = {
         // Variables de control
@@ -743,42 +755,47 @@ const geoMagApp = (function() {
     async function loadCurrentDst() {
         const source = 'dst';
         const startTime = Date.now();
-        
+
         updateSourceStatus(source, 'loading');
-        
+
         try {
             const now = new Date();
             const yearShort = now.getFullYear().toString().slice(-2);
             const month = String(now.getMonth() + 1).padStart(2, '0');
             const url = `${CONFIG.DATA_SOURCES.dstKyoto}dst${yearShort}${month}.for.request`;
-            
+
             const response = await fetchWithCORS(url, {
                 source: source,
                 timeout: CONFIG.SOURCE_TIMEOUTS.dst
             });
-            
+
             const text = await response.text();
             const lines = text.split('\n');
             let latestDst = null;
-            
+
             for (const line of lines) {
                 if (line.startsWith('DST')) {
-                    const nums = line.match(/[+-]?\d+/g);
-                    if (!nums || nums.length < 4) continue;
-                    const day = parseInt(nums[1]);
-                    if (day === now.getUTCDate()) {
-                        const values = nums.slice(3, 27).map(v => parseInt(v));
-                        const hour = now.getUTCHours();
-                        if (hour < values.length) {
-                            const val = values[hour];
-                            if (!isNaN(val) && val !== 9999) {
-                                latestDst = val;
-                            }
+                    // Mejorar el parseo para evitar valores extraños
+                    const parts = line.split(/\s+/);
+                    if (parts.length < 27) continue;
+
+                    const day = parseInt(parts[2]);
+                    if (isNaN(day) || day !== now.getUTCDate()) continue;
+
+                    const hour = now.getUTCHours();
+                    const hourIndex = 3 + hour; // DST values start at index 3
+
+                    if (hourIndex < parts.length) {
+                        const val = parseInt(parts[hourIndex]);
+                        // Validar que el valor esté en un rango razonable (-500 a 200 nT)
+                        if (!isNaN(val) && val !== 9999 && val >= -500 && val <= 200) {
+                            latestDst = val;
+                            break;
                         }
                     }
                 }
             }
-            
+
             const latency = Date.now() - startTime;
             state.validationResults[source] = {
                 status: latestDst !== null ? 'valid' : 'no-data',
@@ -786,10 +803,10 @@ const geoMagApp = (function() {
                 latency: latency,
                 lastUpdate: new Date()
             };
-            
+
             updateSourceStatus(source, latestDst !== null ? 'valid' : 'error');
             return latestDst;
-            
+
         } catch (error) {
             console.error('Error loading DST:', error);
             state.validationResults[source] = {
@@ -806,57 +823,77 @@ const geoMagApp = (function() {
     async function loadKsaIndex() {
         const source = 'ksa';
         const startTime = Date.now();
-        
+
         updateSourceStatus(source, 'loading');
-        
+
         try {
+            // Usar la fecha actual real, no la simulada
             const today = new Date();
             const year = today.getFullYear();
             const dateString = today.toISOString().split('T')[0];
-            let url = `${CONFIG.DATA_SOURCES.ksaEmbraceBase}${year}/${dateString}.txt`;
-            
-            const response = await fetchWithCORS(url, {
-                source: source,
-                timeout: CONFIG.SOURCE_TIMEOUTS.ksa
-            });
-            
-            const text = await response.text();
-            const lines = text.trim().split('\n').filter(line => line.trim());
-            const timestamps = [];
-            const values = [];
-            
-            for (const line of lines) {
-                const parts = line.trim().split(/\s+/);
-                if (parts.length >= 2 && parts[0].match(/^\d{4}-\d{2}-\d{2}/)) {
-                    try {
-                        const time = new Date(parts[0]);
-                        const hour = time.getUTCHours();
-                        timestamps.push(`${hour}h`);
-                        const val = parseFloat(parts[1].replace(/[+-]/g, ''));
-                        if (!isNaN(val)) {
-                            values.push(val);
+
+            // Si no hay datos para hoy, intentar días anteriores
+            let attempts = 0;
+            const maxAttempts = 3;
+            let targetDate = new Date(today);
+
+            while (attempts < maxAttempts) {
+                const tryYear = targetDate.getFullYear();
+                const tryDateString = targetDate.toISOString().split('T')[0];
+                const url = `${CONFIG.DATA_SOURCES.ksaEmbraceBase}${tryYear}/${tryDateString}.txt`;
+
+                try {
+                    const response = await fetchWithCORS(url, {
+                        source: source,
+                        timeout: CONFIG.SOURCE_TIMEOUTS.ksa
+                    });
+
+                    const text = await response.text();
+                    const lines = text.trim().split('\n').filter(line => line.trim());
+                    const timestamps = [];
+                    const values = [];
+
+                    for (const line of lines) {
+                        const parts = line.trim().split(/\s+/);
+                        if (parts.length >= 2 && parts[0].match(/^\d{4}-\d{2}-\d{2}/)) {
+                            try {
+                                const time = new Date(parts[0]);
+                                const hour = time.getUTCHours();
+                                timestamps.push(`${hour}h`);
+                                const val = parseFloat(parts[1].replace(/[+-]/g, ''));
+                                if (!isNaN(val) && val >= 0 && val <= 9) {
+                                    values.push(val);
+                                }
+                            } catch (e) {
+                                console.warn('KSA: Línea con formato inválido:', line);
+                            }
                         }
-                    } catch (e) {
-                        console.warn('KSA: Línea con formato inválido:', line);
                     }
+
+                    if (values.length > 0) {
+                        const latency = Date.now() - startTime;
+                        console.log(`KSA cargado exitosamente: ${values.length} valores de ${tryDateString} en ${latency}ms`);
+                        state.validationResults[source] = {
+                            status: 'valid',
+                            confidence: 95,
+                            latency: latency,
+                            lastUpdate: new Date(),
+                            dataPoints: values.length,
+                            dataDate: tryDateString
+                        };
+                        updateSourceStatus(source, 'valid');
+                        return { timestamps, values };
+                    }
+                } catch (attemptError) {
+                    console.log(`KSA: No hay datos para ${tryDateString}`);
                 }
+
+                // Retroceder un día
+                targetDate.setDate(targetDate.getDate() - 1);
+                attempts++;
             }
-            
-            const latency = Date.now() - startTime;
-            if (values.length > 0) {
-                console.log(`KSA cargado exitosamente: ${values.length} valores en ${latency}ms`);
-                state.validationResults[source] = {
-                    status: 'valid',
-                    confidence: 95,
-                    latency: latency,
-                    lastUpdate: new Date(),
-                    dataPoints: values.length
-                };
-                updateSourceStatus(source, 'valid');
-                return { timestamps, values };
-            }
-            
-            throw new Error('No hay datos disponibles');
+
+            throw new Error('No hay datos KSA disponibles en los últimos 3 días');
             
         } catch (error) {
             console.error('Error loading KSA:', error);
@@ -874,44 +911,61 @@ const geoMagApp = (function() {
     async function loadIntermagnetData(observatory = 'PIL') {
         const source = `intermagnet${observatory}`;
         const startTime = Date.now();
-        
+
         updateSourceStatus(source, 'loading');
-        
+
         try {
-            const today = new Date().toISOString().split('T')[0];
-            const baseUrl = observatory === 'PIL' ? CONFIG.DATA_SOURCES.intermagnetPIL : CONFIG.DATA_SOURCES.intermagnetVSS;
-            const url = `${baseUrl}${today}&dataDuration=1&publicationState=best-avail&format=json`;
-            
-            const response = await fetchWithCORS(url, {
-                source: source,
-                timeout: CONFIG.SOURCE_TIMEOUTS[source] || 5000
-            });
-            
-            const data = await response.json();
-            
-            if (data && data.data && data.data.length > 0) {
-                const latest = data.data[data.data.length - 1];
-                const result = {
-                    timestamp: latest.timestamp,
-                    x: latest.x,
-                    y: latest.y,
-                    z: latest.z,
-                    f: Math.sqrt(latest.x * latest.x + latest.y * latest.y + latest.z * latest.z),
-                    observatory: observatory
-                };
-                
-                state.validationResults[source] = {
-                    status: 'valid',
-                    confidence: 92,
-                    latency: Date.now() - startTime,
-                    lastUpdate: new Date()
-                };
-                
-                updateSourceStatus(source, 'valid');
-                return result;
+            // Usar la fecha de ayer si hoy no tiene datos
+            let targetDate = new Date();
+            let attempts = 0;
+            const maxAttempts = 3; // Intentar hasta 3 días atrás
+
+            while (attempts < maxAttempts) {
+                const dateStr = targetDate.toISOString().split('T')[0];
+                const baseUrl = observatory === 'PIL' ? CONFIG.DATA_SOURCES.intermagnetPIL : CONFIG.DATA_SOURCES.intermagnetVSS;
+                const url = `${baseUrl}${dateStr}&dataDuration=1&publicationState=best-avail&format=json`;
+
+                try {
+                    const response = await fetchWithCORS(url, {
+                        source: source,
+                        timeout: CONFIG.SOURCE_TIMEOUTS[source] || 5000
+                    });
+
+                    const data = await response.json();
+
+                    if (data && data.data && data.data.length > 0) {
+                        const latest = data.data[data.data.length - 1];
+                        const result = {
+                            timestamp: latest.timestamp,
+                            x: latest.x || 0,
+                            y: latest.y || 0,
+                            z: latest.z || 0,
+                            f: Math.sqrt((latest.x || 0) ** 2 + (latest.y || 0) ** 2 + (latest.z || 0) ** 2),
+                            observatory: observatory,
+                            dataDate: dateStr
+                        };
+
+                        state.validationResults[source] = {
+                            status: 'valid',
+                            confidence: 92,
+                            latency: Date.now() - startTime,
+                            lastUpdate: new Date(),
+                            note: attempts > 0 ? `Datos de ${dateStr}` : undefined
+                        };
+
+                        updateSourceStatus(source, 'valid');
+                        return result;
+                    }
+                } catch (attemptError) {
+                    console.log(`Intento ${attempts + 1} falló para ${dateStr}`);
+                }
+
+                // Retroceder un día
+                targetDate.setDate(targetDate.getDate() - 1);
+                attempts++;
             }
-            
-            throw new Error('No hay datos disponibles');
+
+            throw new Error('No hay datos disponibles en los últimos 3 días');
             
         } catch (error) {
             console.error(`Error loading ${observatory} data:`, error);
@@ -1562,24 +1616,39 @@ const geoMagApp = (function() {
     }
 
     function updateStatistics() {
+        // Validar que existan datos antes de procesarlos
         if (!state.forecastData.kpGFZ || state.forecastData.kpGFZ.length === 0) {
-            console.warn('No hay datos Kp para estadísticas');
-            return;
+            // Si no hay datos GFZ, intentar usar otros
+            const alternativeKp = state.forecastData.kpNoaa ||
+                                (state.forecastData.ksaData ? state.forecastData.ksaData.values : []) ||
+                                state.forecastData.hp30 || [];
+
+            if (alternativeKp.length === 0) {
+                console.warn('No hay datos Kp disponibles para estadísticas');
+                return;
+            }
+
+            // Usar datos alternativos
+            state.forecastData.kpGFZ = alternativeKp;
         }
-        
-        const validKpValues = state.forecastData.kpGFZ.filter(v => v !== null && !isNaN(v));
+
+        const validKpValues = state.forecastData.kpGFZ.filter(v => v !== null && !isNaN(v) && v >= 0 && v <= 9);
         if (validKpValues.length === 0) {
             console.warn('No hay valores Kp válidos');
+            document.getElementById('maxKp').textContent = '--';
+            document.getElementById('maxKpTime').textContent = '--';
+            document.getElementById('stormProb').textContent = '0%';
+            document.getElementById('optimalWindow').textContent = '0h';
             return;
         }
-        
+
         const maxKp = Math.max(...validKpValues);
         const maxKpIndex = state.forecastData.kpGFZ.indexOf(maxKp);
         document.getElementById('maxKp').textContent = maxKp.toFixed(1);
         document.getElementById('maxKpTime').textContent = state.forecastData.timestamps[maxKpIndex] || '--';
-        
-        if (state.forecastData.ap.length > 0) {
-            const validApValues = state.forecastData.ap.filter(v => v !== null && !isNaN(v));
+
+        if (state.forecastData.ap && state.forecastData.ap.length > 0) {
+            const validApValues = state.forecastData.ap.filter(v => v !== null && !isNaN(v) && v >= 0);
             if (validApValues.length > 0) {
                 const maxAp = Math.max(...validApValues);
                 const maxApIndex = state.forecastData.ap.indexOf(maxAp);
@@ -1587,10 +1656,10 @@ const geoMagApp = (function() {
                 document.getElementById('maxApTime').textContent = state.forecastData.timestamps[maxApIndex] || '--';
             }
         }
-        
+
         const stormProb = calculateStormProbability();
         document.getElementById('stormProb').textContent = `${stormProb.toFixed(0)}%`;
-        
+
         const optimalHours = validKpValues.filter(kp => kp * state.forecastData.samaFactor < 4).length;
         document.getElementById('optimalWindow').textContent = `${optimalHours}h`;
         document.getElementById('optimalHours').textContent = `de ${state.forecastData.timestamps.length}h totales`;
@@ -1736,11 +1805,19 @@ const geoMagApp = (function() {
         return Math.min(100, probability);
     }
 
+    // Mostrar mensaje de carga en el panel de estado
+    function showLoadingMessage(message) {
+        const statusElement = document.getElementById('systemStatus');
+        if (statusElement) {
+            statusElement.textContent = message;
+        }
+    }
+
     // ================== FUNCIONES PÚBLICAS ==================
-    
+
     async function refreshData() {
         document.getElementById('chartLoading').style.display = 'flex';
-        document.getElementById('systemStatus').textContent = 'Actualizando...';
+        showLoadingMessage('Conectando con fuentes de datos...');
         
         try {
             const success = await loadDataHybrid();


### PR DESCRIPTION
## Summary
- discard unrealistic DST values (e.g., corrupted data lines)
- retry KSA and PIL requests for up to 3 days
- fallback to alternate data in `updateStatistics`
- tweak UI status messages and production timeouts

## Testing
- `node -c geomagnetic-monitor.js`


------
https://chatgpt.com/codex/tasks/task_e_684ffc0803f0832ba24bd4202c3f8088