### PR TITLE
Add flight status on mobile page

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Monitor Geomagnético Móvil</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 10px; background:#0f172a; color:#f1f5f9; }
+        h1 { text-align:center; font-size:1.4rem; margin-bottom:10px; }
+        canvas { width:100%; height:200px; margin-bottom:5px; background:#1e293b; border-radius:8px; }
+        .chart-msg { text-align:center; font-size:0.8rem; color:#facc15; margin-bottom:15px; }
+        section { margin-bottom:20px; }
+        p { margin-top:5px; font-size:0.9rem; }
+    </style>
+</head>
+<body>
+    <h1>Monitor Geomagnético Móvil</h1>
+    <section>
+        <canvas id="ksaChart"></canvas>
+        <div id="ksaMsg" class="chart-msg"></div>
+    </section>
+    <section>
+        <canvas id="kpChart"></canvas>
+        <div id="kpMsg" class="chart-msg"></div>
+    </section>
+    <section>
+        <canvas id="hpChart"></canvas>
+        <div id="hpMsg" class="chart-msg"></div>
+    </section>
+    <section id="flightStatus" style="text-align:center;font-size:1.2rem;">Cargando datos...</section>
+
+    <section id="explanation">
+        <h2>¿Qué representan estos índices?</h2>
+        <p><strong>KSA (EMBRACE):</strong> Índice K Sudamericano. Máxima prioridad para la región.</p>
+        <p><strong>Kp NOAA:</strong> Pronóstico oficial del Space Weather Prediction Center de NOAA.</p>
+        <p><strong>HP30 GFZ:</strong> Índice de alta resolución (30 minutos) del Helmholtz Centre for Geosciences.</p>
+    </section>
+
+    <script src="mobile.js"></script>
+</body>
+</html>

--- a/mobile.js
+++ b/mobile.js
@@ -1,0 +1,127 @@
+async function fetchKSA() {
+    const now = new Date();
+    for (let i = 0; i < 3; i++) {
+        const date = new Date(now.getTime() - i * 24*60*60*1000);
+        const year = date.getUTCFullYear();
+        const dateStr = date.toISOString().split('T')[0];
+        const url = `https://embracedata.inpe.br/ksa/${year}/${dateStr}.txt`;
+        try {
+            const res = await fetch(url);
+            if (!res.ok) continue;
+            const text = await res.text();
+            const lines = text.trim().split('\n');
+            const labels = [];
+            const values = [];
+            for (const line of lines) {
+                const parts = line.trim().split(/\s+/);
+                if (parts.length >= 2) {
+                    const time = new Date(parts[0]);
+                    labels.push(`${time.getUTCHours()}h`);
+                    const val = parseFloat(parts[1]);
+                    if (!isNaN(val)) values.push(val);
+                }
+            }
+            if (values.length) return {labels, values};
+        } catch(e) {
+            console.error('KSA fetch error', e);
+        }
+    }
+    return {labels:[], values:[]};
+}
+
+async function fetchKP() {
+    const url = 'https://services.swpc.noaa.gov/text/3-day-geomag-forecast.txt';
+    const res = await fetch(url);
+    const text = await res.text();
+    const lines = text.split('\n');
+    const pattern = /(\d{2}-\d{2})UT/;
+    let start = -1;
+    for (let i=0;i<lines.length;i++) {
+        if (pattern.test(lines[i]) && lines[i].includes('00-03UT')) { start=i; break; }
+    }
+    if (start===-1) return {labels:[], values:[]};
+    const labels=[];
+    const values=[];
+    for (let j=0;j<8;j++) {
+        const line = lines[start+j] || '';
+        const nums = line.match(/\b(\d+\.?\d*)\b/g);
+        if (nums && nums[1]) {
+            const val = parseFloat(nums[1]);
+            values.push(val);
+            const hrs = line.slice(0,5).replace(/UT|\s/g,'');
+            labels.push(hrs);
+        }
+    }
+    return {labels, values};
+}
+
+async function fetchHP30() {
+    const end = new Date();
+    const start = new Date(end.getTime()-24*60*60*1000);
+    const startStr = start.toISOString().slice(0,19)+'Z';
+    const endStr = end.toISOString().slice(0,19)+'Z';
+    const url = `https://kp.gfz.de/app/json/?start=${startStr}&end=${endStr}&index=Hp30`;
+    const res = await fetch(url);
+    const data = await res.json();
+    const labels = data.datetime.map(t => {
+        const d = new Date(t);
+        return `${d.getUTCHours()}:${('0'+d.getUTCMinutes()).slice(-2)}`;
+    });
+    return {labels, values: data.Hp30 || []};
+}
+
+function createChart(ctx, label, data){
+    if (typeof Chart === 'undefined') return null;
+    return new Chart(ctx, {
+        type:'line',
+        data:{ labels:data.labels, datasets:[{ label, data:data.values, borderColor:'#3b82f6', backgroundColor:'rgba(59,130,246,0.3)', fill:true }] },
+        options:{ scales:{ x:{ ticks:{ color:'#f1f5f9'} }, y:{ ticks:{ color:'#f1f5f9'} } }, plugins:{ legend:{ labels:{ color:'#f1f5f9' } } } }
+    });
+}
+
+function computeCurrentKp(ksaLatest, kpNoaa) {
+    let sum = 0;
+    let weight = 0;
+    if (kpNoaa != null) { sum += kpNoaa * 0.6; weight += 0.6; }
+    if (ksaLatest != null) { sum += ksaLatest * 0.4; weight += 0.4; }
+    return weight ? sum / weight : null;
+}
+
+function estimatePrecision(kp) {
+    if (kp >= 7) return '±10-30m';
+    if (kp >= 5) return '±5-10m';
+    if (kp >= 4) return '±2-5m';
+    return '±1m';
+}
+
+function updateFlightStatus(kpVal) {
+    const el = document.getElementById('flightStatus');
+    if (kpVal == null) {
+        el.textContent = 'Datos insuficientes';
+        return;
+    }
+    const precision = estimatePrecision(kpVal);
+    const allowed = kpVal < 5;
+    el.innerHTML = `Apto para volar: <strong>${allowed ? 'Sí' : 'No'}</strong><br>Precisión GPS: ${precision}`;
+}
+
+async function init(){
+    const ksa = await fetchKSA();
+    createChart(document.getElementById('ksaChart').getContext('2d'),'KSA', ksa);
+    document.getElementById('ksaMsg').textContent = ksa.labels.length ? '' : 'Sin datos';
+
+    const kp = await fetchKP();
+    createChart(document.getElementById('kpChart').getContext('2d'),'Kp NOAA', kp);
+    document.getElementById('kpMsg').textContent = kp.labels.length ? '' : 'Sin datos';
+
+    const hp = await fetchHP30();
+    createChart(document.getElementById('hpChart').getContext('2d'),'HP30', hp);
+    document.getElementById('hpMsg').textContent = hp.labels.length ? '' : 'Sin datos';
+
+    const latestKsa = ksa.values[ksa.values.length - 1];
+    const kpVal = kp.values[0];
+    const currentKp = computeCurrentKp(latestKsa, kpVal);
+    updateFlightStatus(currentKp);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ Sistema de monitoreo y predicción de actividad geomagnética optimizado para op
 - **Predicción 72 horas**: Pronóstico integrado con múltiples modelos
 - **Recomendaciones operacionales**: Sistema de alertas específico para drones
 - **Validación en tiempo real**: Monitoreo del estado y calidad de todas las fuentes de datos
+- **Versión móvil simplificada**: Gráficos de KSA, Kp NOAA y HP30 con indicador "Apto para volar"
 
 ## 📊 Índices Monitoreados
 
@@ -67,21 +68,25 @@ cd geomagnetic-monitor
 ```bash
 # En Linux/Mac
 open index.html
+open mobile.html
 
 # En Windows
 start index.html
+start mobile.html
 ```
+La versión móvil muestra los índices principales y un estado "Apto para volar".
 
 ### Despliegue en Servidor Web
 
 1. Sube los archivos a tu servidor web:
 ```bash
-scp index.html geomagnetic-monitor.js usuario@servidor:/var/www/html/
+scp index.html geomagnetic-monitor.js mobile.html mobile.js usuario@servidor:/var/www/html/
 ```
 
 2. Accede desde cualquier navegador:
 ```
 https://tudominio.com/index.html
+https://tudominio.com/mobile.html
 ```
 
 ## 📡 Fuentes de Datos


### PR DESCRIPTION
## Summary
- enhance the mobile version with small status messages and a new flight status section
- calculate a weighted Kp from KSA and NOAA data to indicate "Apto para volar" and estimated GPS precision
- document the mobile page in the README

## Testing
- `node --version`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685049780c04832bb5e437d7253d2ac4